### PR TITLE
Add Notion-style shortcuts

### DIFF
--- a/apps/client/src/components/layouts/global/global-app-shell.tsx
+++ b/apps/client/src/components/layouts/global/global-app-shell.tsx
@@ -15,6 +15,8 @@ import Aside from "@/components/layouts/global/aside.tsx";
 import classes from "./app-shell.module.css";
 import { useTrialEndAction } from "@/ee/hooks/use-trial-end-action.tsx";
 import { useToggleSidebar } from "@/components/layouts/global/hooks/hooks/use-toggle-sidebar.ts";
+import { searchSpotlight } from "@/features/search/constants";
+import { useWindowEvent } from "@mantine/hooks";
 
 export default function GlobalAppShell({
   children,
@@ -29,6 +31,14 @@ export default function GlobalAppShell({
   const [sidebarWidth, setSidebarWidth] = useAtom(sidebarWidthAtom);
   const [isResizing, setIsResizing] = useState(false);
   const sidebarRef = useRef(null);
+
+  useWindowEvent("keydown", (event) => {
+    const key = event.key.toLowerCase();
+    if ((event.metaKey || event.ctrlKey) && (key === "p" || key === "k")) {
+      event.preventDefault();
+      searchSpotlight.open();
+    }
+  });
 
   const startResizing = React.useCallback((mouseDownEvent) => {
     mouseDownEvent.preventDefault();

--- a/apps/client/src/features/editor/extensions/extensions.ts
+++ b/apps/client/src/features/editor/extensions/extensions.ts
@@ -73,6 +73,7 @@ import i18n from "@/i18n.ts";
 import { MarkdownClipboard } from "@/features/editor/extensions/markdown-clipboard.ts";
 import EmojiCommand from "./emoji-command";
 import { CharacterCount } from "@tiptap/extension-character-count";
+import { EditorShortcuts } from "@docmost/editor-ext";
 
 const lowlight = createLowlight(common);
 lowlight.register("mermaid", plaintext);
@@ -213,6 +214,7 @@ export const mainExtensions = [
   MarkdownClipboard.configure({
     transformPastedText: true,
   }),
+  EditorShortcuts,
   CharacterCount
 ] as any;
 

--- a/packages/editor-ext/src/index.ts
+++ b/packages/editor-ext/src/index.ts
@@ -17,3 +17,4 @@ export * from "./lib/excalidraw";
 export * from "./lib/embed";
 export * from "./lib/mention";
 export * from "./lib/markdown";
+export * from "./lib/editor-shortcuts";

--- a/packages/editor-ext/src/lib/editor-shortcuts.ts
+++ b/packages/editor-ext/src/lib/editor-shortcuts.ts
@@ -1,0 +1,23 @@
+import { Extension } from '@tiptap/core';
+
+export const EditorShortcuts = Extension.create({
+  name: 'editor-shortcuts',
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Shift-7': () => this.editor.commands.toggleOrderedList(),
+      'Mod-Shift-8': () => this.editor.commands.toggleBulletList(),
+      'Mod-Shift-9': () => this.editor.commands.toggleTaskList(),
+      'Mod-Alt-1': () => this.editor.commands.toggleHeading({ level: 1 }),
+      'Mod-Alt-2': () => this.editor.commands.toggleHeading({ level: 2 }),
+      'Mod-Alt-3': () => this.editor.commands.toggleHeading({ level: 3 }),
+      'Mod-Alt-4': () => this.editor.commands.toggleHeading({ level: 4 }),
+      'Mod-Alt-5': () => this.editor.commands.toggleHeading({ level: 5 }),
+      'Mod-Alt-6': () => this.editor.commands.toggleHeading({ level: 6 }),
+      'Mod-Alt-0': () => this.editor.commands.setParagraph(),
+      'Mod-E': () => this.editor.commands.toggleCode(),
+      'Mod-Shift-S': () => this.editor.commands.toggleStrike(),
+      'Mod-U': () => this.editor.commands.toggleUnderline(),
+    };
+  },
+});

--- a/shortcut-readme.md
+++ b/shortcut-readme.md
@@ -1,0 +1,21 @@
+# Shortcut Guide (macOS)
+
+Docmost supports various keyboard shortcuts inspired by a popular note-taking tool.
+
+## Global
+
+- **⌘P** or **⌘K** – Open search spotlight
+
+## Editor
+
+- **⌘B** – Toggle bold
+- **⌘I** – Toggle italic
+- **⌘U** – Toggle underline
+- **⌘E** – Toggle inline code
+- **⌘⇧S** – Toggle strikethrough
+- **⌘⇧8** – Bullet list
+- **⌘⇧7** – Numbered list
+- **⌘⇧9** – To‑do list
+- **⌥⌘1** … **⌥⌘6** – Heading levels 1‑6
+- **⌥⌘0** – Paragraph
+- **/** – Open command menu


### PR DESCRIPTION
## Summary
- add a NotionShortcuts extension to register common shortcuts
- enable ⌘P/⌘K to open search spotlight
- document shortcuts in shortcut-readme.md

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68463171ddbc8326a3e133de581c7dd2