### PR TITLE
Add AI assistant with local provider

### DIFF
--- a/LLM_SETUP.md
+++ b/LLM_SETUP.md
@@ -1,0 +1,14 @@
+# LLM Integration Setup
+
+The AI chat feature relies on environment variables configured on the server. Add the following keys to your `.env` file:
+
+```
+OPENAI_API_KEY=your-openai-key
+OPENAI_API_BASE=https://api.openai.com/v1
+HUGGINGFACE_API_KEY=your-huggingface-key
+HUGGINGFACE_API_BASE=https://api-inference.huggingface.co/models/your-model
+LOCAL_LLM_API_BASE=http://localhost:11434
+LOCAL_LLM_MODEL=your-model-name
+```
+
+Only providers with valid configuration will be offered to the client.

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -8,6 +8,7 @@ import WorkspaceMembers from "@/pages/settings/workspace/workspace-members";
 import WorkspaceSettings from "@/pages/settings/workspace/workspace-settings";
 import Groups from "@/pages/settings/group/groups";
 import GroupInfo from "./pages/settings/group/group-info";
+import AiChat from "@/pages/ai/chat";
 import Spaces from "@/pages/settings/space/spaces.tsx";
 import { Error404 } from "@/components/ui/error-404.tsx";
 import AccountPreferences from "@/pages/settings/account/account-preferences.tsx";
@@ -67,6 +68,7 @@ export default function App() {
 
         <Route element={<Layout />}>
           <Route path={"/home"} element={<Home />} />
+          <Route path={"/ai"} element={<AiChat />} />
           <Route path={"/s/:spaceSlug"} element={<SpaceHome />} />
           <Route
             path={"/s/:spaceSlug/p/:pageSlug"}

--- a/apps/client/src/features/ai/components/page-ai-assistant.tsx
+++ b/apps/client/src/features/ai/components/page-ai-assistant.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+import { Modal, Stack, Select, Textarea, Button, Group } from "@mantine/core";
+import { fetchModels, sendChat } from "@/features/ai/services/ai-service";
+import { useAtomValue } from "jotai";
+import { pageEditorAtom } from "@/features/editor/atoms/editor-atoms";
+
+interface AiAssistantProps {
+  opened: boolean;
+  onClose: () => void;
+}
+
+interface Message {
+  role: string;
+  content: string;
+}
+
+export default function PageAiAssistant({ opened, onClose }: AiAssistantProps) {
+  const editor = useAtomValue(pageEditorAtom);
+  const [models, setModels] = useState<string[]>([]);
+  const [provider, setProvider] = useState<string | null>(null);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("\");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchModels().then(setModels).catch(() => setModels([]));
+  }, []);
+
+  useEffect(() => {
+    if (opened && editor) {
+      const text = editor.getText();
+      setMessages([{ role: "system", content: `Current page content:\n${text}` }]);
+    }
+  }, [opened, editor]);
+
+  const handleSend = async () => {
+    if (!provider || !input) return;
+    const next = [...messages, { role: "user", content: input }];
+    setMessages(next);
+    setInput("\");
+    setLoading(true);
+    try {
+      const res = await sendChat({ provider, messages: next });
+      setMessages([...next, { role: "assistant", content: res.message }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleApply = () => {
+    const last = messages[messages.length - 1];
+    if (last?.role === "assistant" && editor) {
+      editor.chain().focus().insertContent(last.content).run();
+    }
+    onClose();
+  };
+
+  return (
+    <Modal opened={opened} onClose={onClose} size={600} title="AI Assistant">
+      <Stack>
+        <Select
+          label="Model"
+          data={models}
+          value={provider}
+          onChange={setProvider}
+          allowDeselect={false}
+        />
+        <div style={{ maxHeight: 200, overflowY: "auto" }}>
+          {messages.map((m, i) => (
+            <div key={i} style={{ marginBottom: 4 }}>
+              <b>{m.role}:</b> {m.content}
+            </div>
+          ))}
+        </div>
+        <Textarea
+          value={input}
+          onChange={(e) => setInput(e.currentTarget.value)}
+          minRows={3}
+        />
+        <Group justify="flex-end">
+          <Button onClick={handleSend} disabled={loading || !provider || !input}>
+            Send
+          </Button>
+          <Button onClick={handleApply} disabled={!messages.find((m) => m.role === "assistant")}>Apply</Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/apps/client/src/features/ai/services/ai-service.ts
+++ b/apps/client/src/features/ai/services/ai-service.ts
@@ -1,0 +1,14 @@
+import api from "@/lib/api-client";
+
+export interface ChatRequest {
+  provider: string;
+  messages: { role: string; content: string }[];
+}
+
+export async function fetchModels(): Promise<string[]> {
+  return api.get("/ai/models");
+}
+
+export async function sendChat(data: ChatRequest): Promise<{ message: string }> {
+  return api.post("/ai/chat", data);
+}

--- a/apps/client/src/features/page/components/header/page-header-menu.tsx
+++ b/apps/client/src/features/page/components/header/page-header-menu.tsx
@@ -3,6 +3,7 @@ import {
   IconArrowRight,
   IconArrowsHorizontal,
   IconDots,
+  IconSparkles,
   IconFileExport,
   IconHistory,
   IconLink,
@@ -12,7 +13,7 @@ import {
   IconTrash,
   IconWifiOff,
 } from "@tabler/icons-react";
-import React from "react";
+import React, { useState } from "react";
 import useToggleAside from "@/hooks/use-toggle-aside.tsx";
 import { useAtom } from "jotai";
 import { historyAtoms } from "@/features/page-history/atoms/history-atoms.ts";
@@ -36,6 +37,7 @@ import { formattedDate, timeAgo } from "@/lib/time.ts";
 import MovePageModal from "@/features/page/components/move-page-modal.tsx";
 import { useTimeAgo } from "@/hooks/use-time-ago.tsx";
 import ShareModal from "@/features/share/components/share-modal.tsx";
+import PageAiAssistant from "@/features/ai/components/page-ai-assistant";
 
 interface PageHeaderMenuProps {
   readOnly?: boolean;
@@ -44,6 +46,7 @@ export default function PageHeaderMenu({ readOnly }: PageHeaderMenuProps) {
   const { t } = useTranslation();
   const toggleAside = useToggleAside();
   const [yjsConnectionStatus] = useAtom(yjsConnectionStatusAtom);
+  const [aiOpen, setAiOpen] = useState(false);
 
   return (
     <>
@@ -80,6 +83,17 @@ export default function PageHeaderMenu({ readOnly }: PageHeaderMenuProps) {
           <IconList size={20} stroke={2} />
         </ActionIcon>
       </Tooltip>
+
+      <Tooltip label={t("AI Assistant")} openDelay={250} withArrow>
+        <ActionIcon
+          variant="default"
+          style={{ border: "none" }}
+          onClick={() => setAiOpen(true)}
+        >
+          <IconSparkles size={20} stroke={2} />
+        </ActionIcon>
+      </Tooltip>
+      <PageAiAssistant opened={aiOpen} onClose={() => setAiOpen(false)} />
 
       <PageActionMenu readOnly={readOnly} />
     </>

--- a/apps/client/src/pages/ai/chat.tsx
+++ b/apps/client/src/pages/ai/chat.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import { Container, Select, Textarea, Button, Stack } from "@mantine/core";
+import { Helmet } from "react-helmet-async";
+import { useTranslation } from "react-i18next";
+import { fetchModels, sendChat } from "@/features/ai/services/ai-service";
+
+interface Message {
+  role: string;
+  content: string;
+}
+
+export default function AiChat() {
+  const { t } = useTranslation();
+  const [models, setModels] = useState<string[]>([]);
+  const [provider, setProvider] = useState<string | null>(null);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchModels().then(setModels).catch(() => setModels([]));
+  }, []);
+
+  const handleSend = async () => {
+    if (!provider || !input) return;
+    const next = [...messages, { role: "user", content: input }];
+    setMessages(next);
+    setInput("");
+    setLoading(true);
+    try {
+      const res = await sendChat({ provider, messages: next });
+      setMessages([...next, { role: "assistant", content: res.message }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Container size={600} pt="md">
+      <Helmet>
+        <title>{t("AI Chat")}</title>
+      </Helmet>
+      <Stack>
+        <Select
+          label={t("Model")}
+          data={models}
+          value={provider}
+          onChange={setProvider}
+          allowDeselect={false}
+        />
+        <Textarea
+          value={input}
+          onChange={(e) => setInput(e.currentTarget.value)}
+          minRows={3}
+        />
+        <Button onClick={handleSend} disabled={loading || !provider || !input}>
+          {t("Send")}
+        </Button>
+        {messages.map((m, i) => (
+          <div key={i}>
+            <b>{m.role}:</b> {m.content}
+          </div>
+        ))}
+      </Stack>
+    </Container>
+  );
+}

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -16,6 +16,7 @@ import { ExportModule } from './integrations/export/export.module';
 import { ImportModule } from './integrations/import/import.module';
 import { SecurityModule } from './integrations/security/security.module';
 import { TelemetryModule } from './integrations/telemetry/telemetry.module';
+import { LlmModule } from './integrations/llm/llm.module';
 
 const enterpriseModules = [];
 try {
@@ -52,6 +53,7 @@ try {
     EventEmitterModule.forRoot(),
     SecurityModule,
     TelemetryModule,
+    LlmModule,
     ...enterpriseModules,
   ],
   controllers: [AppController],

--- a/apps/server/src/integrations/environment/environment.service.ts
+++ b/apps/server/src/integrations/environment/environment.service.ts
@@ -189,4 +189,31 @@ export class EnvironmentService {
       .toLowerCase();
     return disable === 'true';
   }
+
+  getOpenaiApiKey(): string {
+    return this.configService.get<string>('OPENAI_API_KEY');
+  }
+
+  getOpenaiApiBase(): string {
+    return (
+      this.configService.get<string>('OPENAI_API_BASE') ||
+      'https://api.openai.com/v1'
+    );
+  }
+
+  getHuggingfaceApiKey(): string {
+    return this.configService.get<string>('HUGGINGFACE_API_KEY');
+  }
+
+  getHuggingfaceApiBase(): string {
+    return this.configService.get<string>('HUGGINGFACE_API_BASE');
+  }
+
+  getLocalLlmApiBase(): string {
+    return this.configService.get<string>('LOCAL_LLM_API_BASE');
+  }
+
+  getLocalLlmModel(): string {
+    return this.configService.get<string>('LOCAL_LLM_MODEL');
+  }
 }

--- a/apps/server/src/integrations/environment/environment.validation.ts
+++ b/apps/server/src/integrations/environment/environment.validation.ts
@@ -68,6 +68,27 @@ export class EnvironmentVariables {
   )
   @ValidateIf((obj) => obj.CLOUD === 'true'.toLowerCase())
   SUBDOMAIN_HOST: string;
+
+  @IsOptional()
+  OPENAI_API_KEY: string;
+
+  @IsOptional()
+  @IsUrl({ protocols: ['http', 'https'], require_tld: false })
+  OPENAI_API_BASE: string;
+
+  @IsOptional()
+  HUGGINGFACE_API_KEY: string;
+
+  @IsOptional()
+  @IsUrl({ protocols: ['http', 'https'], require_tld: false })
+  HUGGINGFACE_API_BASE: string;
+
+  @IsOptional()
+  @IsUrl({ protocols: ['http', 'https'], require_tld: false })
+  LOCAL_LLM_API_BASE: string;
+
+  @IsOptional()
+  LOCAL_LLM_MODEL: string;
 }
 
 export function validate(config: Record<string, any>) {

--- a/apps/server/src/integrations/llm/dto/chat.dto.ts
+++ b/apps/server/src/integrations/llm/dto/chat.dto.ts
@@ -1,0 +1,15 @@
+import { IsArray, IsEnum } from 'class-validator';
+import { LlmProvider } from '../llm.types';
+
+export class ChatMessage {
+  role: string;
+  content: string;
+}
+
+export class ChatDto {
+  @IsEnum(LlmProvider)
+  provider: LlmProvider;
+
+  @IsArray()
+  messages: ChatMessage[];
+}

--- a/apps/server/src/integrations/llm/llm.controller.ts
+++ b/apps/server/src/integrations/llm/llm.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Post, Body, HttpCode, HttpStatus, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { LlmService } from './llm.service';
+import { ChatDto } from './dto/chat.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('ai')
+export class LlmController {
+  constructor(private readonly llmService: LlmService) {}
+
+  @Get('models')
+  @HttpCode(HttpStatus.OK)
+  getModels() {
+    return this.llmService.getProviders();
+  }
+
+  @Post('chat')
+  @HttpCode(HttpStatus.OK)
+  async chat(@Body() dto: ChatDto) {
+    const message = await this.llmService.chat(dto.provider, dto.messages);
+    return { message };
+  }
+}

--- a/apps/server/src/integrations/llm/llm.module.ts
+++ b/apps/server/src/integrations/llm/llm.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { LlmService } from './llm.service';
+import { LlmController } from './llm.controller';
+
+@Global()
+@Module({
+  providers: [LlmService],
+  controllers: [LlmController],
+  exports: [LlmService],
+})
+export class LlmModule {}

--- a/apps/server/src/integrations/llm/llm.service.ts
+++ b/apps/server/src/integrations/llm/llm.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+import { EnvironmentService } from '../environment/environment.service';
+import { LlmProvider } from './llm.types';
+
+@Injectable()
+export class LlmService {
+  constructor(private readonly environmentService: EnvironmentService) {}
+
+  getProviders(): string[] {
+    const providers: string[] = [];
+    if (this.environmentService.getOpenaiApiKey()) {
+      providers.push(LlmProvider.OpenAI);
+    }
+    if (this.environmentService.getHuggingfaceApiKey()) {
+      providers.push(LlmProvider.HuggingFace);
+    }
+    if (this.environmentService.getLocalLlmApiBase()) {
+      providers.push(LlmProvider.Local);
+    }
+    return providers;
+  }
+
+  async chat(provider: LlmProvider, messages: any[]): Promise<string> {
+    switch (provider) {
+      case LlmProvider.OpenAI:
+        return this.callOpenAI(messages);
+      case LlmProvider.HuggingFace:
+        return this.callHuggingFace(messages);
+      case LlmProvider.Local:
+        return this.callLocal(messages);
+      default:
+        throw new Error('Unknown provider');
+    }
+  }
+
+  private async callOpenAI(messages: any[]): Promise<string> {
+    const apiKey = this.environmentService.getOpenaiApiKey();
+    const base = this.environmentService.getOpenaiApiBase();
+    const res = await fetch(`${base}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ model: 'gpt-3.5-turbo', messages }),
+    });
+    const data = await res.json();
+    return data.choices?.[0]?.message?.content || '';
+  }
+
+  private async callHuggingFace(messages: any[]): Promise<string> {
+    const apiKey = this.environmentService.getHuggingfaceApiKey();
+    const base = this.environmentService.getHuggingfaceApiBase();
+    const prompt = messages.map((m) => m.content).join('\n');
+    const res = await fetch(base, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ inputs: prompt }),
+    });
+    const data = await res.json();
+    if (typeof data === 'string') {
+      return data;
+    }
+    return data.generated_text || '';
+  }
+
+  private async callLocal(messages: any[]): Promise<string> {
+    const base = this.environmentService.getLocalLlmApiBase();
+    const model = this.environmentService.getLocalLlmModel() || 'default';
+    const res = await fetch(`${base}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model, messages }),
+    });
+    const data = await res.json();
+    return data.choices?.[0]?.message?.content || '';
+  }
+}

--- a/apps/server/src/integrations/llm/llm.types.ts
+++ b/apps/server/src/integrations/llm/llm.types.ts
@@ -1,0 +1,5 @@
+export enum LlmProvider {
+  OpenAI = 'openai',
+  HuggingFace = 'huggingface',
+  Local = 'local',
+}


### PR DESCRIPTION
## Summary
- support a local LLM endpoint for Ollama or LM Studio
- expose helper getters for local LLM config
- allow the server to return `local` as a provider
- add an AI assistant modal to pages so generated text can be inserted
- document new environment variables

## Testing
- `pnpm --filter ./apps/server lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm --filter ./apps/client lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684678d96a948326a1b32282ff4bce97