### PR TITLE
Add AI assistant with local provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,10 @@ POSTMARK_TOKEN=
 DRAWIO_URL=
 
 DISABLE_TELEMETRY=false
+
+# OPENAI_API_KEY=your-openai-key
+# OPENAI_API_BASE=https://api.openai.com/v1
+# HUGGINGFACE_API_KEY=your-huggingface-key
+# HUGGINGFACE_API_BASE=https://api-inference.huggingface.co/models/your-model
+# LOCAL_LLM_API_BASE=http://localhost:11434
+# LOCAL_LLM_MODEL=your-model-name

--- a/LLM_SETUP.md
+++ b/LLM_SETUP.md
@@ -1,0 +1,14 @@
+# LLM Integration Setup
+
+The AI chat feature relies on environment variables configured on the server. Add the following keys to your `.env` file:
+
+```
+OPENAI_API_KEY=your-openai-key
+OPENAI_API_BASE=https://api.openai.com/v1
+HUGGINGFACE_API_KEY=your-huggingface-key
+HUGGINGFACE_API_BASE=https://api-inference.huggingface.co/models/your-model
+LOCAL_LLM_API_BASE=http://localhost:11434
+LOCAL_LLM_MODEL=your-model-name
+```
+
+Only providers with valid configuration will be offered to the client.

--- a/apps/client/public/locales/en-US/translation.json
+++ b/apps/client/public/locales/en-US/translation.json
@@ -4,6 +4,7 @@
   "Add": "Add",
   "Add group members": "Add group members",
   "Add groups": "Add groups",
+  "AI Chat": "AI Chat",
   "Add members": "Add members",
   "Add to groups": "Add to groups",
   "Add space members": "Add space members",

--- a/apps/client/public/locales/ko-KR/translation.json
+++ b/apps/client/public/locales/ko-KR/translation.json
@@ -4,6 +4,7 @@
   "Add": "추가",
   "Add group members": "팀에 사용자 추가",
   "Add groups": "팀 생성",
+  "AI Chat": "AI 채팅",
   "Add members": "사용자 추가",
   "Add to groups": "팀에 추가",
   "Add space members": "Space에 사용자 추가",

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -8,6 +8,7 @@ import WorkspaceMembers from "@/pages/settings/workspace/workspace-members";
 import WorkspaceSettings from "@/pages/settings/workspace/workspace-settings";
 import Groups from "@/pages/settings/group/groups";
 import GroupInfo from "./pages/settings/group/group-info";
+import AiChat from "@/pages/ai/chat";
 import Spaces from "@/pages/settings/space/spaces.tsx";
 import { Error404 } from "@/components/ui/error-404.tsx";
 import AccountPreferences from "@/pages/settings/account/account-preferences.tsx";
@@ -67,6 +68,7 @@ export default function App() {
 
         <Route element={<Layout />}>
           <Route path={"/home"} element={<Home />} />
+          <Route path={"/ai"} element={<AiChat />} />
           <Route path={"/s/:spaceSlug"} element={<SpaceHome />} />
           <Route
             path={"/s/:spaceSlug/p/:pageSlug"}

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -68,7 +68,7 @@ export default function App() {
 
         <Route element={<Layout />}>
           <Route path={"/home"} element={<Home />} />
-          <Route path={"/ai"} element={<AiChat />} />
+          <Route path={"/ai/chat"} element={<AiChat />} />
           <Route path={"/s/:spaceSlug"} element={<SpaceHome />} />
           <Route
             path={"/s/:spaceSlug/p/:pageSlug"}

--- a/apps/client/src/components/layouts/global/app-header.tsx
+++ b/apps/client/src/components/layouts/global/app-header.tsx
@@ -14,8 +14,12 @@ import SidebarToggle from "@/components/ui/sidebar-toggle-button.tsx";
 import { useTranslation } from "react-i18next";
 import useTrial from "@/ee/hooks/use-trial.tsx";
 import { isCloud } from "@/lib/config.ts";
+import { IconSparkles } from "@tabler/icons-react";
 
-const links = [{ link: APP_ROUTE.HOME, label: "Home" }];
+const links = [
+  { link: APP_ROUTE.HOME, label: "Home" },
+  { link: APP_ROUTE.AI.CHAT, label: "AI Chat", icon: IconSparkles }
+];
 
 export function AppHeader() {
   const { t } = useTranslation();

--- a/apps/client/src/features/ai/components/page-ai-assistant.module.css
+++ b/apps/client/src/features/ai/components/page-ai-assistant.module.css
@@ -1,0 +1,114 @@
+/* AI Assistant modal styles with proper dark mode support */
+
+.modalHeader {
+  border-bottom: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  background: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
+}
+
+.modelSection {
+  border-bottom: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  background: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-8));
+}
+
+.inputSection {
+  border-top: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  background: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
+}
+
+.messageUserBubble {
+  background-color: light-dark(var(--mantine-color-blue-0), var(--mantine-color-dark-6)) !important;
+  color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-dark-0)) !important;
+  border: 1px solid light-dark(var(--mantine-color-blue-2), var(--mantine-color-dark-5));
+  box-shadow: light-dark(
+    0 1px 3px rgba(0, 0, 0, 0.1),
+    0 1px 3px rgba(0, 0, 0, 0.3)
+  );
+}
+
+.messageAssistantBubble {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-8)) !important;
+  color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-dark-0)) !important;
+  border: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+  box-shadow: light-dark(
+    0 1px 3px rgba(0, 0, 0, 0.1),
+    0 1px 3px rgba(0, 0, 0, 0.3)
+  );
+}
+
+.loadingPaper {
+  background: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-7)) !important;
+  color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-dark-0)) !important;
+  border: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+.messageText {
+  color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-dark-0)) !important;
+  line-height: 1.6;
+  word-wrap: break-word;
+  hyphens: auto;
+}
+
+.messageText pre {
+  background: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-6));
+  border: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  border-radius: var(--mantine-radius-sm);
+  padding: var(--mantine-spacing-xs);
+  overflow-x: auto;
+  margin: var(--mantine-spacing-xs) 0;
+}
+
+.messageText code {
+  background: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-6));
+  border: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  border-radius: var(--mantine-radius-xs);
+  padding: 2px 4px;
+  font-family: var(--mantine-font-family-monospace);
+  font-size: 0.875em;
+}
+
+.emptyStateText {
+  color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-gray-4)) !important;
+}
+
+.actionText {
+  color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-gray-4)) !important;
+  transition: color 150ms ease;
+}
+
+.actionText:hover {
+  color: light-dark(var(--mantine-color-blue-6), var(--mantine-color-blue-4)) !important;
+}
+
+.timestampText {
+  color: light-dark(var(--mantine-color-dimmed), var(--mantine-color-dark-3)) !important;
+  font-size: 0.75rem;
+}
+
+.scrollArea {
+  height: 100%;
+}
+
+.scrollArea [data-radix-scroll-area-viewport] {
+  scroll-behavior: smooth;
+}
+
+.retryButton {
+  background: light-dark(var(--mantine-color-yellow-1), var(--mantine-color-yellow-9));
+  color: light-dark(var(--mantine-color-yellow-9), var(--mantine-color-yellow-1));
+  border: 1px solid light-dark(var(--mantine-color-yellow-3), var(--mantine-color-yellow-7));
+}
+
+.errorMessage {
+  background: light-dark(var(--mantine-color-red-0), var(--mantine-color-red-9));
+  color: light-dark(var(--mantine-color-red-9), var(--mantine-color-red-0));
+  border: 1px solid light-dark(var(--mantine-color-red-3), var(--mantine-color-red-7));
+  border-radius: var(--mantine-radius-md);
+  padding: var(--mantine-spacing-sm);
+  margin: var(--mantine-spacing-xs) 0;
+}

--- a/apps/client/src/features/ai/components/page-ai-assistant.tsx
+++ b/apps/client/src/features/ai/components/page-ai-assistant.tsx
@@ -1,8 +1,40 @@
-import { useEffect, useState } from "react";
-import { Modal, Stack, Select, Textarea, Button, Group } from "@mantine/core";
-import { fetchModels, sendChat } from "@/features/ai/services/ai-service";
+import { useEffect, useState, useRef, useCallback, useMemo } from "react";
+import { 
+  Modal, 
+  Stack, 
+  Select, 
+  Textarea, 
+  Button, 
+  Group, 
+  Text,
+  Box,
+  ActionIcon,
+  ScrollArea,
+  Badge,
+  Paper,
+  Divider,
+  Loader,
+  ThemeIcon,
+  UnstyledButton,
+  Tooltip
+} from "@mantine/core";
+import { 
+  IconRobot, 
+  IconUser, 
+  IconSend, 
+  IconCheck, 
+  IconCopy, 
+  IconRefresh,
+  IconSparkles,
+  IconFileText,
+  IconEdit
+} from "@tabler/icons-react";
+import { fetchModels, sendModelChat } from "@/features/ai/services/ai-service";
 import { useAtomValue } from "jotai";
 import { pageEditorAtom } from "@/features/editor/atoms/editor-atoms";
+import { notifications } from "@mantine/notifications";
+import { AIModel, ChatMessage } from "../types/ai.types";
+import classes from "./page-ai-assistant.module.css";
 
 interface AiAssistantProps {
   opened: boolean;
@@ -10,80 +42,470 @@ interface AiAssistantProps {
 }
 
 interface Message {
-  role: string;
+  role: "user" | "assistant" | "system";
   content: string;
+  timestamp: Date;
+  id: string;
 }
+
+// Constants
+const SCROLL_BEHAVIOR: ScrollBehavior = "smooth";
+const MAX_RETRIES = 3;
+const DEBOUNCE_DELAY = 300;
 
 export default function PageAiAssistant({ opened, onClose }: AiAssistantProps) {
   const editor = useAtomValue(pageEditorAtom);
-  const [models, setModels] = useState<string[]>([]);
-  const [provider, setProvider] = useState<string | null>(null);
+  const [models, setModels] = useState<AIModel[]>([]);
+  const [selectedModel, setSelectedModel] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const [pageContent, setPageContent] = useState("");
+  const [retryCount, setRetryCount] = useState(0);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
-    fetchModels().then(setModels).catch(() => setModels([]));
+  // Memoized values
+  const userMessages = useMemo(() => 
+    messages.filter(m => m.role !== "system"), 
+    [messages]
+  );
+
+  const isInputValid = useMemo(() => 
+    selectedModel && input.trim().length > 0, 
+    [selectedModel, input]
+  );
+
+  const modelOptions = useMemo(() => 
+    models.map(m => ({ value: m.id, label: m.name })),
+    [models]
+  );
+
+  // Callbacks
+  const scrollToBottom = useCallback(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: SCROLL_BEHAVIOR });
   }, []);
 
-  useEffect(() => {
-    if (opened && editor) {
-      const text = editor.getText();
-      setMessages([{ role: "system", content: `Current page content:\n${text}` }]);
+  const loadModels = useCallback(async () => {
+    try {
+      const data = await fetchModels();
+      if (Array.isArray(data) && data.length > 0) {
+        setModels(data);
+        if (!selectedModel && data.length > 0) {
+          setSelectedModel(data[0].id);
+        }
+      } else {
+        setModels([]);
+        notifications.show({
+          title: "No AI Models",
+          message: "No AI models are currently available. Please check your configuration.",
+          color: "yellow"
+        });
+      }
+    } catch (error: any) {
+      console.error('Error fetching models:', error);
+      setModels([]);
+      notifications.show({
+        title: "Connection Error",
+        message: "Failed to load AI models. Please check your configuration.",
+        color: "red"
+      });
     }
-  }, [opened, editor]);
+  }, [selectedModel]);
 
-  const handleSend = async () => {
-    if (!provider || !input) return;
-    const next = [...messages, { role: "user", content: input }];
-    setMessages(next);
+  const generateMessageId = useCallback(() => {
+    return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  }, []);
+
+  const handleSend = useCallback(async () => {
+    if (!isInputValid) return;
+    
+    const userMessage: Message = {
+      role: "user",
+      content: input.trim(),
+      timestamp: new Date(),
+      id: generateMessageId()
+    };
+    
+    const updatedMessages = [...messages, userMessage];
+    setMessages(updatedMessages);
     setInput("");
     setLoading(true);
+    setRetryCount(0);
+    
     try {
-      const res = await sendChat({ provider, messages: next });
-      setMessages([...next, { role: "assistant", content: res.message }]);
+      const chatMessages = updatedMessages
+        .filter(m => m.role !== "system")
+        .map(m => ({ role: m.role, content: m.content }));
+      
+      if (pageContent) {
+        chatMessages.unshift({
+          role: "system",
+          content: `You are an AI writing assistant. The user is working on a document with this content:\n\n${pageContent}\n\nHelp them improve, edit, or extend this content. Provide specific, actionable suggestions.`
+        });
+      }
+      
+      const res = await sendModelChat(selectedModel!, chatMessages);
+      
+      const assistantMessage: Message = {
+        role: "assistant",
+        content: res.message,
+        timestamp: new Date(),
+        id: generateMessageId()
+      };
+      
+      setMessages([...updatedMessages, assistantMessage]);
+    } catch (error: any) {
+      console.error('Chat error:', error);
+      
+      if (retryCount < MAX_RETRIES) {
+        setRetryCount(prev => prev + 1);
+        notifications.show({
+          title: "Retrying...",
+          message: `Attempt ${retryCount + 1}/${MAX_RETRIES}`,
+          color: "yellow"
+        });
+        setTimeout(() => handleSend(), 1000 * Math.pow(2, retryCount));
+      } else {
+        notifications.show({
+          title: "Error",
+          message: error?.message || "Failed to get response from AI",
+          color: "red",
+          autoClose: 5000
+        });
+      }
     } finally {
       setLoading(false);
     }
-  };
+  }, [isInputValid, input, messages, selectedModel, pageContent, retryCount, generateMessageId]);
 
-  const handleApply = () => {
-    const last = messages[messages.length - 1];
-    if (last?.role === "assistant" && editor) {
-      editor.chain().focus().insertContent(last.content).run();
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      handleSend();
     }
-    onClose();
-  };
+  }, [handleSend]);
+
+  const handleApplyToDocument = useCallback((content: string) => {
+    if (editor) {
+      editor.chain().focus().insertContent(content).run();
+      notifications.show({
+        title: "Applied to document",
+        message: "Content has been added to your document",
+        color: "green",
+        icon: <IconCheck size={16} />
+      });
+    }
+  }, [editor]);
+
+  const handleCopyMessage = useCallback(async (content: string) => {
+    try {
+      await navigator.clipboard.writeText(content);
+      notifications.show({
+        title: "Copied",
+        message: "Message copied to clipboard",
+        color: "blue",
+        icon: <IconCopy size={16} />
+      });
+    } catch (error) {
+      console.error('Failed to copy to clipboard:', error);
+      notifications.show({
+        title: "Copy Failed",
+        message: "Unable to copy to clipboard",
+        color: "red"
+      });
+    }
+  }, []);
+
+  const handleReplaceDocument = useCallback((content: string) => {
+    if (editor) {
+      editor.chain().focus().selectAll().insertContent(content).run();
+      notifications.show({
+        title: "Document replaced",
+        message: "Document content has been replaced",
+        color: "green",
+        icon: <IconEdit size={16} />
+      });
+      onClose();
+    }
+  }, [editor, onClose]);
+
+  const clearChat = useCallback(() => {
+    setMessages([]);
+    setInput("");
+    notifications.show({
+      title: "Chat cleared",
+      message: "Conversation has been cleared",
+      color: "blue"
+    });
+  }, []);
+
+  // Effects
+  useEffect(() => {
+    if (opened) {
+      loadModels();
+      inputRef.current?.focus();
+    }
+  }, [opened, loadModels]);
+
+  useEffect(() => {
+    if (opened && editor) {
+      const text = editor.getText().trim();
+      setPageContent(text);
+      
+      if (text) {
+        const systemMessage: Message = {
+          role: "system",
+          content: `You are an AI writing assistant helping to edit a document. Here is the current content:\n\n${text}\n\nHelp the user improve, edit, or extend this content.`,
+          timestamp: new Date(),
+          id: generateMessageId()
+        };
+        setMessages([systemMessage]);
+      } else {
+        setMessages([]);
+      }
+    }
+  }, [opened, editor, generateMessageId]);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, scrollToBottom]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      setMessages([]);
+      setInput("");
+      setLoading(false);
+    };
+  }, []);
 
   return (
-    <Modal opened={opened} onClose={onClose} size={600} title="AI Assistant">
-      <Stack>
-        <Select
-          label="Model"
-          data={models}
-          value={provider}
-          onChange={setProvider}
-          allowDeselect={false}
-        />
-        <div style={{ maxHeight: 200, overflowY: "auto" }}>
-          {messages.map((m, i) => (
-            <div key={i} style={{ marginBottom: 4 }}>
-              <b>{m.role}:</b> {m.content}
-            </div>
-          ))}
-        </div>
-        <Textarea
-          value={input}
-          onChange={(e) => setInput(e.currentTarget.value)}
-          minRows={3}
-        />
-        <Group justify="flex-end">
-          <Button onClick={handleSend} disabled={loading || !provider || !input}>
-            Send
-          </Button>
-          <Button onClick={handleApply} disabled={!messages.find((m) => m.role === "assistant")}>Apply</Button>
+    <Modal 
+      opened={opened} 
+      onClose={onClose} 
+      size="lg" 
+      title={
+        <Group>
+          <ThemeIcon size="sm" color="blue" variant="light" aria-hidden>
+            <IconSparkles size={16} />
+          </ThemeIcon>
+          <Text fw={600}>AI Writing Assistant</Text>
         </Group>
+      }
+      styles={{
+        body: { padding: 0 },
+        header: { padding: "16px 20px" }
+      }}
+      classNames={{
+        header: classes.modalHeader
+      }}
+      aria-label="AI Writing Assistant"
+      trapFocus
+      closeOnEscape
+    >
+      <Stack gap={0} h={600} role="main" aria-label="AI chat interface">
+        {/* Model Selection */}
+        <Box p="md" className={classes.modelSection} role="region" aria-label="Model selection">
+          <Group justify="space-between">
+            <Select
+              label="AI Model"
+              placeholder="Select a model"
+              data={modelOptions}
+              value={selectedModel}
+              onChange={setSelectedModel}
+              leftSection={<IconRobot size={16} aria-hidden />}
+              flex={1}
+              size="sm"
+              aria-describedby="model-help"
+              required
+            />
+            <Text id="model-help" size="xs" c="dimmed" style={{ display: 'none' }}>
+              Choose an AI model to chat with
+            </Text>
+            {userMessages.length > 0 && (
+              <Tooltip label="Clear conversation">
+                <ActionIcon 
+                  variant="light" 
+                  color="gray" 
+                  onClick={clearChat}
+                  mt="xl"
+                  aria-label="Clear conversation history"
+                >
+                  <IconRefresh size={16} aria-hidden />
+                </ActionIcon>
+              </Tooltip>
+            )}
+          </Group>
+        </Box>
+
+        {/* Messages Area */}
+        <ScrollArea 
+          flex={1} 
+          p="md" 
+          type="scroll"
+          className={classes.scrollArea}
+          role="log"
+          aria-label="Chat messages"
+          aria-live="polite"
+        >
+          {userMessages.length === 0 ? (
+            <Stack align="center" justify="center" h={300} role="status">
+              <ThemeIcon size={48} color="blue" variant="light" aria-hidden>
+                <IconSparkles size={24} />
+              </ThemeIcon>
+              <Text c="dimmed" ta="center" size="sm" className={classes.emptyStateText}>
+                Ask me anything about your document.<br />
+                I can help you write, edit, improve, or extend your content.
+              </Text>
+              {pageContent && (
+                <Badge 
+                  variant="light" 
+                  color="blue" 
+                  leftSection={<IconFileText size={12} aria-hidden />}
+                  aria-label={`Document loaded with ${pageContent.length} characters`}
+                >
+                  Document loaded ({pageContent.length} characters)
+                </Badge>
+              )}
+            </Stack>
+          ) : (
+            <Stack gap="md">
+              {userMessages.map((message) => (
+                <MessageBubble
+                  key={message.id}
+                  message={message}
+                  onApply={handleApplyToDocument}
+                  onCopy={handleCopyMessage}
+                  onReplace={handleReplaceDocument}
+                  showActions={message.role === "assistant"}
+                />
+              ))}
+              {loading && (
+                <Paper 
+                  p="md" 
+                  radius="md" 
+                  className={classes.loadingPaper}
+                  role="status"
+                  aria-label="AI is processing your message"
+                >
+                  <Group>
+                    <ThemeIcon size="sm" color="blue" variant="light" aria-hidden>
+                      <IconRobot size={14} />
+                    </ThemeIcon>
+                    <Loader size="xs" aria-hidden />
+                    <Text size="sm" c="dimmed">AI is thinking...</Text>
+                  </Group>
+                </Paper>
+              )}
+              <div ref={messagesEndRef} aria-hidden />
+            </Stack>
+          )}
+        </ScrollArea>
+
+        {/* Input Area */}
+        <Box p="md" className={classes.inputSection} role="region" aria-label="Message input">
+          <Stack gap="xs">
+            <Textarea
+              ref={inputRef}
+              placeholder="Ask me to help with your writing..."
+              value={input}
+              onChange={(e) => setInput(e.currentTarget.value)}
+              onKeyDown={handleKeyDown}
+              minRows={2}
+              maxRows={4}
+              autosize
+              disabled={!selectedModel}
+              aria-label="Type your message to the AI assistant"
+              aria-describedby="input-help"
+            />
+            <Text id="input-help" size="xs" c="dimmed" style={{ display: 'none' }}>
+              Press Command+Enter to send your message
+            </Text>
+            <Group justify="space-between">
+              <Text size="xs" c="dimmed" aria-label="Keyboard shortcut">
+                Press ⌘+Enter to send
+              </Text>
+              <Button
+                onClick={handleSend}
+                disabled={!isInputValid || loading}
+                leftSection={<IconSend size={16} aria-hidden />}
+                size="sm"
+                loading={loading}
+                aria-label="Send message to AI assistant"
+              >
+                Send
+              </Button>
+            </Group>
+          </Stack>
+        </Box>
       </Stack>
     </Modal>
+  );
+}
+
+interface MessageBubbleProps {
+  message: Message;
+  onApply: (content: string) => void;
+  onCopy: (content: string) => void;
+  onReplace: (content: string) => void;
+  showActions: boolean;
+}
+
+function MessageBubble({ message, onApply, onCopy, onReplace, showActions }: MessageBubbleProps) {
+  const isUser = message.role === "user";
+  
+  return (
+    <Group align="flex-start" gap="sm">
+      <ThemeIcon 
+        size="sm" 
+        color={isUser ? "gray" : "blue"} 
+        variant="light"
+        mt={4}
+      >
+        {isUser ? <IconUser size={14} /> : <IconRobot size={14} />}
+      </ThemeIcon>
+      
+      <Stack gap="xs" flex={1}>
+        <Paper
+          p="md"
+          radius="md"
+          className={isUser ? classes.messageUserBubble : classes.messageAssistantBubble}
+          style={{
+            maxWidth: isUser ? "80%" : "100%",
+            alignSelf: isUser ? "flex-end" : "flex-start"
+          }}
+        >
+          <Text size="sm" style={{ whiteSpace: "pre-wrap" }} className={classes.messageText}>
+            {message.content}
+          </Text>
+        </Paper>
+        
+        {showActions && (
+          <Group gap="xs">
+            <UnstyledButton onClick={() => onCopy(message.content)}>
+              <Group gap={4}>
+                <IconCopy size={12} />
+                <Text size="xs" className={classes.actionText}>Copy</Text>
+              </Group>
+            </UnstyledButton>
+            
+            <UnstyledButton onClick={() => onApply(message.content)}>
+              <Group gap={4}>
+                <IconCheck size={12} />
+                <Text size="xs" className={classes.actionText}>Insert</Text>
+              </Group>
+            </UnstyledButton>
+            
+            <UnstyledButton onClick={() => onReplace(message.content)}>
+              <Group gap={4}>
+                <IconEdit size={12} />
+                <Text size="xs" className={classes.actionText}>Replace document</Text>
+              </Group>
+            </UnstyledButton>
+          </Group>
+        )}
+      </Stack>
+    </Group>
   );
 }

--- a/apps/client/src/features/ai/components/page-ai-assistant.tsx
+++ b/apps/client/src/features/ai/components/page-ai-assistant.tsx
@@ -19,7 +19,7 @@ export default function PageAiAssistant({ opened, onClose }: AiAssistantProps) {
   const [models, setModels] = useState<string[]>([]);
   const [provider, setProvider] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
-  const [input, setInput] = useState("\");
+  const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -37,7 +37,7 @@ export default function PageAiAssistant({ opened, onClose }: AiAssistantProps) {
     if (!provider || !input) return;
     const next = [...messages, { role: "user", content: input }];
     setMessages(next);
-    setInput("\");
+    setInput("");
     setLoading(true);
     try {
       const res = await sendChat({ provider, messages: next });

--- a/apps/client/src/features/ai/components/page-ai-assistant.tsx
+++ b/apps/client/src/features/ai/components/page-ai-assistant.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+import { Modal, Stack, Select, Textarea, Button, Group } from "@mantine/core";
+import { fetchModels, sendChat } from "@/features/ai/services/ai-service";
+import { useAtomValue } from "jotai";
+import { pageEditorAtom } from "@/features/editor/atoms/editor-atoms";
+
+interface AiAssistantProps {
+  opened: boolean;
+  onClose: () => void;
+}
+
+interface Message {
+  role: string;
+  content: string;
+}
+
+export default function PageAiAssistant({ opened, onClose }: AiAssistantProps) {
+  const editor = useAtomValue(pageEditorAtom);
+  const [models, setModels] = useState<string[]>([]);
+  const [provider, setProvider] = useState<string | null>(null);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("\");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchModels().then(setModels).catch(() => setModels([]));
+  }, []);
+
+  useEffect(() => {
+    if (opened && editor) {
+      const text = editor.getText();
+      setMessages([{ role: "system", content: `Current page content:\n${text}` }]);
+    }
+  }, [opened, editor]);
+
+  const handleSend = async () => {
+    if (!provider || !input) return;
+    const next = [...messages, { role: "user", content: input }];
+    setMessages(next);
+    setInput("\");
+    setLoading(true);
+    try {
+      const res = await sendChat({ provider, messages: next });
+      setMessages([...next, { role: "assistant", content: res.message }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleApply = () => {
+    const last = messages[messages.length - 1];
+    if (last?.role === "assistant" && editor) {
+      editor.chain().focus().insertContent(last.content).run();
+    }
+    onClose();
+  };
+
+  return (
+    <Modal opened={opened} onClose={onClose} size={600} title="AI Assistant">
+      <Stack>
+        <Select
+          label="Model"
+          data={models}
+          value={provider}
+          onChange={setProvider}
+          allowDeselect={false}
+        />
+        <div style={{ maxHeight: 200, overflowY: "auto" }}>
+          {messages.map((m, i) => (
+            <div key={i} style={{ marginBottom: 4 }}>
+              <b>{m.role}:</b> {m.content}
+            </div>
+          ))}
+        </div>
+        <Textarea
+          value={input}
+          onChange={(e) => setInput(e.currentTarget.value)}
+          minRows={3}
+        />
+        <Group justify="flex-end">
+          <Button onClick={handleSend} disabled={loading || !provider || !input}>
+            Send
+          </Button>
+          <Button onClick={handleApply} disabled={!messages.find((m) => m.role === "assistant")}>Apply</Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/apps/client/src/features/ai/hooks/use-ai-chat.ts
+++ b/apps/client/src/features/ai/hooks/use-ai-chat.ts
@@ -1,0 +1,88 @@
+import { useCallback, useRef, useEffect } from 'react';
+
+/**
+ * Custom hook for debouncing function calls
+ */
+export function useDebounce<T extends (...args: any[]) => void>(
+  callback: T,
+  delay: number
+): T {
+  const timeoutRef = useRef<NodeJS.Timeout>();
+
+  const debouncedCallback = useCallback(
+    (...args: Parameters<T>) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      
+      timeoutRef.current = setTimeout(() => {
+        callback(...args);
+      }, delay);
+    },
+    [callback, delay]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return debouncedCallback as T;
+}
+
+/**
+ * Custom hook for auto-saving input
+ */
+export function useAutoSave<T>(
+  value: T,
+  onSave: (value: T) => void,
+  delay: number = 1000
+) {
+  const debouncedSave = useDebounce(onSave, delay);
+
+  useEffect(() => {
+    if (value) {
+      debouncedSave(value);
+    }
+  }, [value, debouncedSave]);
+}
+
+/**
+ * Custom hook for managing AI chat state
+ */
+export function useChatState() {
+  const abortControllerRef = useRef<AbortController>();
+
+  const createAbortSignal = useCallback(() => {
+    // Cancel previous request if still pending
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+    
+    abortControllerRef.current = new AbortController();
+    return abortControllerRef.current.signal;
+  }, []);
+
+  const cancelCurrentRequest = useCallback(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      // Cleanup on unmount
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+    };
+  }, []);
+
+  return {
+    createAbortSignal,
+    cancelCurrentRequest
+  };
+}

--- a/apps/client/src/features/ai/services/ai-service.ts
+++ b/apps/client/src/features/ai/services/ai-service.ts
@@ -1,0 +1,14 @@
+import api from "@/lib/api-client";
+
+export interface ChatRequest {
+  provider: string;
+  messages: { role: string; content: string }[];
+}
+
+export async function fetchModels(): Promise<string[]> {
+  return api.get("/ai/models");
+}
+
+export async function sendChat(data: ChatRequest): Promise<{ message: string }> {
+  return api.post("/ai/chat", data);
+}

--- a/apps/client/src/features/ai/services/ai-service.ts
+++ b/apps/client/src/features/ai/services/ai-service.ts
@@ -1,14 +1,95 @@
 import api from "@/lib/api-client";
+import { AIModel, ChatRequest, ChatResponse, ModelChatRequest } from "../types/ai.types";
 
-export interface ChatRequest {
-  provider: string;
-  messages: { role: string; content: string }[];
+// Re-export types for convenience
+export type { AIModel, ChatRequest, ChatResponse, ModelChatRequest };
+
+export async function fetchModels(): Promise<AIModel[]> {
+  try {
+    const response = await api.get("/ai/models");
+    
+    if (!response.data) {
+      console.warn('fetchModels: received empty response');
+      return [];
+    }
+    
+    if (Array.isArray(response.data)) {
+      return response.data;
+    } else {
+      console.warn('fetchModels: expected array, got:', typeof response.data);
+      return [];
+    }
+  } catch (error: any) {
+    console.warn('AI models endpoint not available:', error?.message || error);
+    return [];
+  }
 }
 
-export async function fetchModels(): Promise<string[]> {
-  return api.get("/ai/models");
+export async function fetchProviders(): Promise<string[]> {
+  try {
+    const response = await api.get("/ai/providers");
+    
+    if (!response.data) {
+      console.warn('fetchProviders: received empty response');
+      return [];
+    }
+    
+    if (Array.isArray(response.data)) {
+      return response.data;
+    } else {
+      console.warn('fetchProviders: expected array, got:', typeof response.data);
+      return [];
+    }
+  } catch (error: any) {
+    console.warn('AI providers endpoint not available:', error?.message || error);
+    return [];
+  }
 }
 
-export async function sendChat(data: ChatRequest): Promise<{ message: string }> {
-  return api.post("/ai/chat", data);
+export async function sendChat(data: ChatRequest): Promise<ChatResponse> {
+  try {
+    const response = await api.post("/ai/chat", data);
+    
+    if (!response.data?.message) {
+      throw new Error('Invalid response format: missing message');
+    }
+    
+    return response.data;
+  } catch (error: any) {
+    console.error('AI chat endpoint error:', error?.message || error);
+    throw new Error('AI chat is not available. Please check your configuration.');
+  }
+}
+
+export async function sendModelChat(modelId: string, messages: { role: string; content: string }[]): Promise<ChatResponse> {
+  if (!modelId?.trim()) {
+    throw new Error('Model ID is required');
+  }
+  
+  if (!Array.isArray(messages) || messages.length === 0) {
+    throw new Error('Messages array is required and cannot be empty');
+  }
+  
+  try {
+    const payload: ModelChatRequest = { modelId, messages };
+    const response = await api.post("/ai/chat/model", payload);
+    
+    if (!response.data?.message) {
+      throw new Error('Invalid response format: missing message');
+    }
+    
+    return response.data;
+  } catch (error: any) {
+    console.error('AI model chat endpoint error:', error?.message || error);
+    
+    if (error?.response?.status === 404) {
+      throw new Error('AI service is not configured or available');
+    } else if (error?.response?.status === 429) {
+      throw new Error('Too many requests. Please wait and try again.');
+    } else if (error?.response?.status >= 500) {
+      throw new Error('AI service is temporarily unavailable');
+    }
+    
+    throw new Error('Failed to get response from AI. Please try again.');
+  }
 }

--- a/apps/client/src/features/ai/types/ai.types.ts
+++ b/apps/client/src/features/ai/types/ai.types.ts
@@ -1,0 +1,36 @@
+// AI related TypeScript types
+
+export interface AIModel {
+  id: string;
+  name: string;
+  provider: string;
+}
+
+export interface ChatMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+  timestamp: Date;
+  id: string;
+}
+
+export interface ChatRequest {
+  provider: string;
+  messages: Array<{ role: string; content: string }>;
+}
+
+export interface ModelChatRequest {
+  modelId: string;
+  messages: Array<{ role: string; content: string }>;
+}
+
+export interface ChatResponse {
+  message: string;
+}
+
+export type MessageRole = "user" | "assistant" | "system";
+
+export interface MessageAction {
+  type: "copy" | "apply" | "replace";
+  label: string;
+  icon: React.ComponentType<{ size?: number }>;
+}

--- a/apps/client/src/features/page/components/header/page-header-menu.tsx
+++ b/apps/client/src/features/page/components/header/page-header-menu.tsx
@@ -3,6 +3,7 @@ import {
   IconArrowRight,
   IconArrowsHorizontal,
   IconDots,
+  IconSparkles,
   IconFileExport,
   IconHistory,
   IconLink,
@@ -12,7 +13,7 @@ import {
   IconTrash,
   IconWifiOff,
 } from "@tabler/icons-react";
-import React from "react";
+import React, { useState } from "react";
 import useToggleAside from "@/hooks/use-toggle-aside.tsx";
 import { useAtom } from "jotai";
 import { historyAtoms } from "@/features/page-history/atoms/history-atoms.ts";
@@ -36,6 +37,7 @@ import { formattedDate, timeAgo } from "@/lib/time.ts";
 import MovePageModal from "@/features/page/components/move-page-modal.tsx";
 import { useTimeAgo } from "@/hooks/use-time-ago.tsx";
 import ShareModal from "@/features/share/components/share-modal.tsx";
+import PageAiAssistant from "@/features/ai/components/page-ai-assistant";
 
 interface PageHeaderMenuProps {
   readOnly?: boolean;
@@ -44,6 +46,7 @@ export default function PageHeaderMenu({ readOnly }: PageHeaderMenuProps) {
   const { t } = useTranslation();
   const toggleAside = useToggleAside();
   const [yjsConnectionStatus] = useAtom(yjsConnectionStatusAtom);
+  const [aiOpen, setAiOpen] = useState(false);
 
   return (
     <>
@@ -80,6 +83,17 @@ export default function PageHeaderMenu({ readOnly }: PageHeaderMenuProps) {
           <IconList size={20} stroke={2} />
         </ActionIcon>
       </Tooltip>
+
+      <Tooltip label={t("AI Assistant")} openDelay={250} withArrow>
+        <ActionIcon
+          variant="default"
+          style={{ border: "none" }}
+          onClick={() => setAiOpen(true)}
+        >
+          <IconSparkles size={20} stroke={2} />
+        </ActionIcon>
+      </Tooltip>
+      <PageAiAssistant opened={aiOpen} onClose={() => setAiOpen(false)} />
 
       <PageActionMenu readOnly={readOnly} />
     </>

--- a/apps/client/src/lib/app-route.ts
+++ b/apps/client/src/lib/app-route.ts
@@ -1,5 +1,8 @@
 const APP_ROUTE = {
   HOME: "/home",
+  AI: {
+    CHAT: "/ai/chat",
+  },
   AUTH: {
     LOGIN: "/login",
     SIGNUP: "/signup",

--- a/apps/client/src/pages/ai/chat.module.css
+++ b/apps/client/src/pages/ai/chat.module.css
@@ -1,0 +1,63 @@
+/* AI Chat page styles with proper dark mode support */
+
+.header {
+  border-bottom: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+}
+
+.inputArea {
+  border-top: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+}
+
+.messageUserBubble {
+  background-color: light-dark(var(--mantine-color-blue-0), var(--mantine-color-dark-6));
+  color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-dark-0));
+}
+
+.messageAssistantBubble {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-8));
+  color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-dark-0));
+}
+
+.loadingBubble {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-8));
+}
+
+.userName {
+  color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-3));
+}
+
+.assistantName {
+  color: light-dark(var(--mantine-color-blue-7), var(--mantine-color-blue-3));
+}
+
+.messageText {
+  color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-dark-0)) !important;
+}
+
+.textInput {
+  input {
+    border: 2px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)) !important;
+    background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7)) !important;
+    color: light-dark(var(--mantine-color-dark-9), var(--mantine-color-dark-0)) !important;
+    
+    &:focus {
+      border-color: light-dark(var(--mantine-color-blue-5), var(--mantine-color-blue-4)) !important;
+    }
+
+    &::placeholder {
+      color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-3)) !important;
+    }
+  }
+}
+
+.emptyStateText {
+  color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-3));
+}
+
+.timestampText {
+  color: light-dark(var(--mantine-color-dimmed), var(--mantine-color-dark-2));
+}
+
+.characterCountText {
+  color: light-dark(var(--mantine-color-dimmed), var(--mantine-color-dark-2));
+}

--- a/apps/client/src/pages/ai/chat.tsx
+++ b/apps/client/src/pages/ai/chat.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import { Container, Select, Textarea, Button, Stack } from "@mantine/core";
+import { Helmet } from "react-helmet-async";
+import { useTranslation } from "react-i18next";
+import { fetchModels, sendChat } from "@/features/ai/services/ai-service";
+
+interface Message {
+  role: string;
+  content: string;
+}
+
+export default function AiChat() {
+  const { t } = useTranslation();
+  const [models, setModels] = useState<string[]>([]);
+  const [provider, setProvider] = useState<string | null>(null);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchModels().then(setModels).catch(() => setModels([]));
+  }, []);
+
+  const handleSend = async () => {
+    if (!provider || !input) return;
+    const next = [...messages, { role: "user", content: input }];
+    setMessages(next);
+    setInput("");
+    setLoading(true);
+    try {
+      const res = await sendChat({ provider, messages: next });
+      setMessages([...next, { role: "assistant", content: res.message }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Container size={600} pt="md">
+      <Helmet>
+        <title>{t("AI Chat")}</title>
+      </Helmet>
+      <Stack>
+        <Select
+          label={t("Model")}
+          data={models}
+          value={provider}
+          onChange={setProvider}
+          allowDeselect={false}
+        />
+        <Textarea
+          value={input}
+          onChange={(e) => setInput(e.currentTarget.value)}
+          minRows={3}
+        />
+        <Button onClick={handleSend} disabled={loading || !provider || !input}>
+          {t("Send")}
+        </Button>
+        {messages.map((m, i) => (
+          <div key={i}>
+            <b>{m.role}:</b> {m.content}
+          </div>
+        ))}
+      </Stack>
+    </Container>
+  );
+}

--- a/apps/client/src/pages/ai/chat.tsx
+++ b/apps/client/src/pages/ai/chat.tsx
@@ -1,67 +1,403 @@
-import { useEffect, useState } from "react";
-import { Container, Select, Textarea, Button, Stack } from "@mantine/core";
+import { useEffect, useState, useRef } from "react";
+import { 
+  Container, 
+  Select, 
+  Textarea, 
+  Button, 
+  Stack, 
+  Text,
+  Box,
+  Group,
+  Paper,
+  Avatar,
+  ActionIcon,
+  ScrollArea,
+  Divider,
+  ThemeIcon,
+  UnstyledButton,
+  Loader,
+  Alert,
+  Badge,
+  Tooltip
+} from "@mantine/core";
+import { 
+  IconRobot, 
+  IconUser, 
+  IconSend, 
+  IconCopy, 
+  IconRefresh,
+  IconSparkles,
+  IconTrash,
+  IconDownload,
+  IconSettings
+} from "@tabler/icons-react";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
-import { fetchModels, sendChat } from "@/features/ai/services/ai-service";
+import { fetchModels, sendModelChat, AIModel } from "@/features/ai/services/ai-service";
+import { notifications } from "@mantine/notifications";
+import classes from "./chat.module.css";
 
 interface Message {
-  role: string;
+  id: string;
+  role: "user" | "assistant";
   content: string;
+  timestamp: Date;
 }
 
 export default function AiChat() {
   const { t } = useTranslation();
-  const [models, setModels] = useState<string[]>([]);
-  const [provider, setProvider] = useState<string | null>(null);
+  const [models, setModels] = useState<AIModel[]>([]);
+  const [selectedModel, setSelectedModel] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const [isConnected, setIsConnected] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    fetchModels().then(setModels).catch(() => setModels([]));
+    loadModels();
   }, []);
 
-  const handleSend = async () => {
-    if (!provider || !input) return;
-    const next = [...messages, { role: "user", content: input }];
-    setMessages(next);
-    setInput("");
-    setLoading(true);
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  const loadModels = async () => {
     try {
-      const res = await sendChat({ provider, messages: next });
-      setMessages([...next, { role: "assistant", content: res.message }]);
-    } finally {
-      setLoading(false);
+      const data = await fetchModels();
+      if (Array.isArray(data) && data.length > 0) {
+        setModels(data);
+        setSelectedModel(data[0].id);
+        setIsConnected(true);
+      } else {
+        console.error('No models available');
+        setModels([]);
+        setIsConnected(false);
+      }
+    } catch (error) {
+      console.error('Error fetching models:', error);
+      setModels([]);
+      setIsConnected(false);
+      notifications.show({
+        title: "Connection Error",
+        message: "Failed to connect to AI service. Please check your configuration.",
+        color: "red"
+      });
     }
   };
 
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  const handleSend = async () => {
+    if (!selectedModel || !input.trim()) return;
+    
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      role: "user",
+      content: input.trim(),
+      timestamp: new Date()
+    };
+    
+    const updatedMessages = [...messages, userMessage];
+    setMessages(updatedMessages);
+    setInput("");
+    setLoading(true);
+    
+    try {
+      const chatMessages = updatedMessages.map(m => ({ 
+        role: m.role, 
+        content: m.content 
+      }));
+      
+      const res = await sendModelChat(selectedModel, chatMessages);
+      
+      const assistantMessage: Message = {
+        id: (Date.now() + 1).toString(),
+        role: "assistant",
+        content: res.message,
+        timestamp: new Date()
+      };
+      
+      setMessages([...updatedMessages, assistantMessage]);
+    } catch (error) {
+      console.error('Chat error:', error);
+      notifications.show({
+        title: "Chat Error",
+        message: "Failed to get response from AI. Please try again.",
+        color: "red"
+      });
+    } finally {
+      setLoading(false);
+      inputRef.current?.focus();
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const copyMessage = (content: string) => {
+    navigator.clipboard.writeText(content);
+    notifications.show({
+      title: "Copied",
+      message: "Message copied to clipboard",
+      color: "blue"
+    });
+  };
+
+  const clearChat = () => {
+    setMessages([]);
+    notifications.show({
+      title: "Chat cleared",
+      message: "Conversation history has been cleared",
+      color: "blue"
+    });
+  };
+
+  const exportChat = () => {
+    const chatData = messages.map(m => `${m.role.toUpperCase()}: ${m.content}`).join('\n\n');
+    const blob = new Blob([chatData], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `ai-chat-${new Date().toISOString().split('T')[0]}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
-    <Container size={600} pt="md">
+    <Container size="lg" h="100vh" p={0}>
       <Helmet>
-        <title>{t("AI Chat")}</title>
+        <title>{t("AI Chat")} | Docmost</title>
       </Helmet>
-      <Stack>
-        <Select
-          label={t("Model")}
-          data={models}
-          value={provider}
-          onChange={setProvider}
-          allowDeselect={false}
-        />
-        <Textarea
-          value={input}
-          onChange={(e) => setInput(e.currentTarget.value)}
-          minRows={3}
-        />
-        <Button onClick={handleSend} disabled={loading || !provider || !input}>
-          {t("Send")}
-        </Button>
-        {messages.map((m, i) => (
-          <div key={i}>
-            <b>{m.role}:</b> {m.content}
-          </div>
-        ))}
+      
+      <Stack h="100%" gap={0}>
+        {/* Header */}
+        <Paper p="md" shadow="xs" className={classes.header} style={{ borderRadius: 0 }}>
+          <Group justify="space-between">
+            <Group>
+              <ThemeIcon size="lg" color="blue" variant="light">
+                <IconSparkles size={20} />
+              </ThemeIcon>
+              <div>
+                <Text fw={600} size="lg">AI Assistant</Text>
+                <Text size="sm" c="dimmed">
+                  {isConnected 
+                    ? `Connected • ${models.length} model${models.length !== 1 ? 's' : ''} available`
+                    : "Disconnected • Check configuration"
+                  }
+                </Text>
+              </div>
+            </Group>
+            
+            <Group>
+              {messages.length > 0 && (
+                <>
+                  <Tooltip label="Export chat">
+                    <ActionIcon variant="light" color="blue" onClick={exportChat}>
+                      <IconDownload size={16} />
+                    </ActionIcon>
+                  </Tooltip>
+                  <Tooltip label="Clear chat">
+                    <ActionIcon variant="light" color="red" onClick={clearChat}>
+                      <IconTrash size={16} />
+                    </ActionIcon>
+                  </Tooltip>
+                  <Divider orientation="vertical" />
+                </>
+              )}
+              
+              <Select
+                data={models.map(m => ({ 
+                  value: m.id, 
+                  label: `${m.name}${m.provider ? ` (${m.provider})` : ''}` 
+                }))}
+                value={selectedModel}
+                onChange={setSelectedModel}
+                placeholder="Select AI model"
+                disabled={!isConnected}
+                w={200}
+                size="sm"
+              />
+              
+              <Tooltip label="Refresh models">
+                <ActionIcon variant="light" color="gray" onClick={loadModels}>
+                  <IconRefresh size={16} />
+                </ActionIcon>
+              </Tooltip>
+            </Group>
+          </Group>
+        </Paper>
+
+        {/* Messages Area */}
+        <Box flex={1} style={{ position: "relative" }}>
+          {!isConnected && (
+            <Alert 
+              icon={<IconSettings size={16} />}
+              title="AI Service Not Available" 
+              color="yellow"
+              m="md"
+            >
+              Please configure your AI settings in the environment variables or check if the AI service is running.
+            </Alert>
+          )}
+          
+          {messages.length === 0 && isConnected ? (
+            <Stack align="center" justify="center" h="100%" gap="xl">
+              <ThemeIcon size={80} color="blue" variant="light">
+                <IconSparkles size={40} />
+              </ThemeIcon>
+              <div style={{ textAlign: "center" }}>
+                <Text size="xl" fw={600} mb="xs">Start a conversation</Text>
+                <Text c="dimmed" size="sm" mb="md" className={classes.emptyStateText}>
+                  Ask me anything! I'm here to help you with information, creative tasks, and problem-solving.
+                </Text>
+                <Group justify="center" gap="xs">
+                  <Badge variant="light" color="blue">Creative Writing</Badge>
+                  <Badge variant="light" color="green">Code Help</Badge>
+                  <Badge variant="light" color="purple">Analysis</Badge>
+                  <Badge variant="light" color="orange">Research</Badge>
+                </Group>
+              </div>
+            </Stack>
+          ) : (
+            <ScrollArea h="100%" type="scroll" p="md">
+              <Stack gap="lg">
+                {messages.map((message) => (
+                  <MessageBubble
+                    key={message.id}
+                    message={message}
+                    onCopy={copyMessage}
+                  />
+                ))}
+                {loading && (
+                  <Group>
+                    <Avatar color="blue" radius="xl">
+                      <IconRobot size={20} />
+                    </Avatar>
+                    <Paper p="md" radius="lg" className={classes.loadingBubble} flex={1}>
+                      <Group gap="xs">
+                        <Loader size="xs" />
+                        <Text size="sm" c="dimmed">AI is thinking...</Text>
+                      </Group>
+                    </Paper>
+                  </Group>
+                )}
+              </Stack>
+              <div ref={messagesEndRef} />
+            </ScrollArea>
+          )}
+        </Box>
+
+        {/* Input Area */}
+        <Paper p="md" shadow="xs" className={classes.inputArea}>
+          <Stack gap="sm">
+            <Group align="flex-end" gap="sm">
+              <Textarea
+                ref={inputRef}
+                placeholder="Type your message here..."
+                value={input}
+                onChange={(e) => setInput(e.currentTarget.value)}
+                onKeyDown={handleKeyDown}
+                minRows={1}
+                maxRows={4}
+                autosize
+                flex={1}
+                disabled={!isConnected || !selectedModel}
+                className={classes.textInput}
+                styles={{
+                  input: {
+                    borderRadius: "12px"
+                  }
+                }}
+              />
+              <Button
+                onClick={handleSend}
+                disabled={loading || !selectedModel || !input.trim() || !isConnected}
+                leftSection={<IconSend size={16} />}
+                loading={loading}
+                size="md"
+                radius="lg"
+              >
+                Send
+              </Button>
+            </Group>
+            
+            <Group justify="space-between">
+              <Text size="xs" className={classes.characterCountText}>
+                Press ⌘+Enter to send • {input.length} characters
+              </Text>
+              {selectedModel && (
+                <Group gap="xs">
+                  <Text size="xs" c="dimmed">Using:</Text>
+                  <Badge variant="light" size="xs">
+                    {models.find(m => m.id === selectedModel)?.name || selectedModel}
+                  </Badge>
+                </Group>
+              )}
+            </Group>
+          </Stack>
+        </Paper>
       </Stack>
     </Container>
+  );
+}
+
+interface MessageBubbleProps {
+  message: Message;
+  onCopy: (content: string) => void;
+}
+
+function MessageBubble({ message, onCopy }: MessageBubbleProps) {
+  const isUser = message.role === "user";
+  
+  return (
+    <Group align="flex-start" gap="sm">
+      <Avatar 
+        color={isUser ? "gray" : "blue"} 
+        radius="xl"
+        size="md"
+      >
+        {isUser ? <IconUser size={20} /> : <IconRobot size={20} />}
+      </Avatar>
+      
+      <Box flex={1}>
+        <Group justify="space-between" align="flex-start" mb="xs">
+          <Text size="sm" fw={500} className={isUser ? classes.userName : classes.assistantName}>
+            {isUser ? "You" : "AI Assistant"}
+          </Text>
+          <Group gap="xs">
+            <Text size="xs" className={classes.timestampText}>
+              {message.timestamp.toLocaleTimeString()}
+            </Text>
+            <UnstyledButton onClick={() => onCopy(message.content)}>
+              <ActionIcon size="sm" variant="subtle" color="gray">
+                <IconCopy size={14} />
+              </ActionIcon>
+            </UnstyledButton>
+          </Group>
+        </Group>
+        
+        <Paper
+          p="md"
+          radius="lg"
+          className={isUser ? classes.messageUserBubble : classes.messageAssistantBubble}
+          style={{
+            maxWidth: "100%",
+            wordBreak: "break-word"
+          }}
+        >
+          <Text size="sm" className={classes.messageText} style={{ whiteSpace: "pre-wrap", lineHeight: 1.6 }}>
+            {message.content}
+          </Text>
+        </Paper>
+      </Box>
+    </Group>
   );
 }

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -16,6 +16,7 @@ import { ExportModule } from './integrations/export/export.module';
 import { ImportModule } from './integrations/import/import.module';
 import { SecurityModule } from './integrations/security/security.module';
 import { TelemetryModule } from './integrations/telemetry/telemetry.module';
+import { LlmModule } from './integrations/llm/llm.module';
 
 const enterpriseModules = [];
 try {
@@ -52,6 +53,7 @@ try {
     EventEmitterModule.forRoot(),
     SecurityModule,
     TelemetryModule,
+    LlmModule,
     ...enterpriseModules,
   ],
   controllers: [AppController],

--- a/apps/server/src/integrations/environment/environment.service.ts
+++ b/apps/server/src/integrations/environment/environment.service.ts
@@ -189,4 +189,31 @@ export class EnvironmentService {
       .toLowerCase();
     return disable === 'true';
   }
+
+  getOpenaiApiKey(): string {
+    return this.configService.get<string>('OPENAI_API_KEY');
+  }
+
+  getOpenaiApiBase(): string {
+    return (
+      this.configService.get<string>('OPENAI_API_BASE') ||
+      'https://api.openai.com/v1'
+    );
+  }
+
+  getHuggingfaceApiKey(): string {
+    return this.configService.get<string>('HUGGINGFACE_API_KEY');
+  }
+
+  getHuggingfaceApiBase(): string {
+    return this.configService.get<string>('HUGGINGFACE_API_BASE');
+  }
+
+  getLocalLlmApiBase(): string {
+    return this.configService.get<string>('LOCAL_LLM_API_BASE');
+  }
+
+  getLocalLlmModel(): string {
+    return this.configService.get<string>('LOCAL_LLM_MODEL');
+  }
 }

--- a/apps/server/src/integrations/environment/environment.validation.ts
+++ b/apps/server/src/integrations/environment/environment.validation.ts
@@ -68,6 +68,27 @@ export class EnvironmentVariables {
   )
   @ValidateIf((obj) => obj.CLOUD === 'true'.toLowerCase())
   SUBDOMAIN_HOST: string;
+
+  @IsOptional()
+  OPENAI_API_KEY: string;
+
+  @IsOptional()
+  @IsUrl({ protocols: ['http', 'https'], require_tld: false })
+  OPENAI_API_BASE: string;
+
+  @IsOptional()
+  HUGGINGFACE_API_KEY: string;
+
+  @IsOptional()
+  @IsUrl({ protocols: ['http', 'https'], require_tld: false })
+  HUGGINGFACE_API_BASE: string;
+
+  @IsOptional()
+  @IsUrl({ protocols: ['http', 'https'], require_tld: false })
+  LOCAL_LLM_API_BASE: string;
+
+  @IsOptional()
+  LOCAL_LLM_MODEL: string;
 }
 
 export function validate(config: Record<string, any>) {

--- a/apps/server/src/integrations/llm/dto/chat.dto.ts
+++ b/apps/server/src/integrations/llm/dto/chat.dto.ts
@@ -1,0 +1,15 @@
+import { IsArray, IsEnum } from 'class-validator';
+import { LlmProvider } from '../llm.types';
+
+export class ChatMessage {
+  role: string;
+  content: string;
+}
+
+export class ChatDto {
+  @IsEnum(LlmProvider)
+  provider: LlmProvider;
+
+  @IsArray()
+  messages: ChatMessage[];
+}

--- a/apps/server/src/integrations/llm/dto/model-chat.dto.ts
+++ b/apps/server/src/integrations/llm/dto/model-chat.dto.ts
@@ -1,0 +1,23 @@
+import { IsArray, IsString, IsNotEmpty, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ChatMessage {
+  @IsString()
+  @IsNotEmpty()
+  role: string;
+
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+}
+
+export class ModelChatDto {
+  @IsString()
+  @IsNotEmpty()
+  modelId: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ChatMessage)
+  messages: ChatMessage[];
+}

--- a/apps/server/src/integrations/llm/filters/llm-exception.filter.ts
+++ b/apps/server/src/integrations/llm/filters/llm-exception.filter.ts
@@ -1,0 +1,67 @@
+import { 
+  ExceptionFilter, 
+  Catch, 
+  ArgumentsHost, 
+  HttpException, 
+  HttpStatus,
+  Logger 
+} from '@nestjs/common';
+import { Response } from 'express';
+
+@Catch()
+export class LlmExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(LlmExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
+    let message = 'Internal server error';
+    let details: any = null;
+
+    if (exception instanceof HttpException) {
+      status = exception.getStatus();
+      const responseBody = exception.getResponse();
+      message = typeof responseBody === 'string' 
+        ? responseBody 
+        : (responseBody as any)?.message || message;
+    } else if (exception instanceof Error) {
+      // Handle specific AI service errors
+      if (exception.message.includes('API key')) {
+        status = HttpStatus.UNAUTHORIZED;
+        message = 'AI service authentication failed';
+      } else if (exception.message.includes('rate limit') || exception.message.includes('429')) {
+        status = HttpStatus.TOO_MANY_REQUESTS;
+        message = 'AI service rate limit exceeded';
+      } else if (exception.message.includes('timeout') || exception.message.includes('connect')) {
+        status = HttpStatus.SERVICE_UNAVAILABLE;
+        message = 'AI service is temporarily unavailable';
+      } else if (exception.message.includes('model not found') || exception.message.includes('404')) {
+        status = HttpStatus.NOT_FOUND;
+        message = 'Requested AI model not found';
+      } else {
+        message = 'AI service error occurred';
+        details = process.env.NODE_ENV === 'development' ? exception.message : undefined;
+      }
+      
+      this.logger.error(
+        `LLM Service Error: ${exception.message}`,
+        exception.stack,
+        'LlmExceptionFilter'
+      );
+    }
+
+    const errorResponse = {
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      message,
+      ...(details && { details }),
+      ...(process.env.NODE_ENV === 'development' && { 
+        stack: exception instanceof Error ? exception.stack : undefined 
+      })
+    };
+
+    response.status(status).json(errorResponse);
+  }
+}

--- a/apps/server/src/integrations/llm/llm.config.ts
+++ b/apps/server/src/integrations/llm/llm.config.ts
@@ -1,0 +1,32 @@
+import { IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class LlmConfig {
+  @IsOptional()
+  @IsString()
+  OPENAI_API_KEY?: string;
+
+  @IsOptional()
+  @IsUrl()
+  OPENAI_API_BASE?: string;
+
+  @IsOptional()
+  @IsString()
+  HUGGINGFACE_API_KEY?: string;
+
+  @IsOptional()
+  @IsUrl()
+  HUGGINGFACE_API_BASE?: string;
+
+  @IsOptional()
+  @IsUrl()
+  LOCAL_LLM_API_BASE?: string;
+
+  @IsOptional()
+  @IsString()
+  LOCAL_LLM_MODEL?: string;
+}
+
+export const LLM_CONFIG_DEFAULTS = {
+  OPENAI_API_BASE: 'https://api.openai.com/v1',
+  LOCAL_LLM_MODEL: 'default',
+};

--- a/apps/server/src/integrations/llm/llm.controller.ts
+++ b/apps/server/src/integrations/llm/llm.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Post, Body, HttpCode, HttpStatus, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { LlmService } from './llm.service';
+import { ChatDto } from './dto/chat.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('ai')
+export class LlmController {
+  constructor(private readonly llmService: LlmService) {}
+
+  @Get('models')
+  @HttpCode(HttpStatus.OK)
+  getModels() {
+    return this.llmService.getProviders();
+  }
+
+  @Post('chat')
+  @HttpCode(HttpStatus.OK)
+  async chat(@Body() dto: ChatDto) {
+    const message = await this.llmService.chat(dto.provider, dto.messages);
+    return { message };
+  }
+}

--- a/apps/server/src/integrations/llm/llm.controller.ts
+++ b/apps/server/src/integrations/llm/llm.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Post, Body, HttpCode, HttpStatus, UseGuards } from '@n
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { LlmService } from './llm.service';
 import { ChatDto } from './dto/chat.dto';
+import { ModelChatDto } from './dto/model-chat.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('ai')
@@ -10,7 +11,13 @@ export class LlmController {
 
   @Get('models')
   @HttpCode(HttpStatus.OK)
-  getModels() {
+  async getModels() {
+    return await this.llmService.getModels();
+  }
+
+  @Get('providers')
+  @HttpCode(HttpStatus.OK)
+  getProviders() {
     return this.llmService.getProviders();
   }
 
@@ -18,6 +25,13 @@ export class LlmController {
   @HttpCode(HttpStatus.OK)
   async chat(@Body() dto: ChatDto) {
     const message = await this.llmService.chat(dto.provider, dto.messages);
+    return { message };
+  }
+
+  @Post('chat/model')
+  @HttpCode(HttpStatus.OK)
+  async chatWithModel(@Body() dto: ModelChatDto) {
+    const message = await this.llmService.chatWithModel(dto.modelId, dto.messages);
     return { message };
   }
 }

--- a/apps/server/src/integrations/llm/llm.module.ts
+++ b/apps/server/src/integrations/llm/llm.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { LlmService } from './llm.service';
+import { LlmController } from './llm.controller';
+
+@Global()
+@Module({
+  providers: [LlmService],
+  controllers: [LlmController],
+  exports: [LlmService],
+})
+export class LlmModule {}

--- a/apps/server/src/integrations/llm/llm.service.ts
+++ b/apps/server/src/integrations/llm/llm.service.ts
@@ -8,6 +8,7 @@ export class LlmService {
 
   getProviders(): string[] {
     const providers: string[] = [];
+    
     if (this.environmentService.getOpenaiApiKey()) {
       providers.push(LlmProvider.OpenAI);
     }
@@ -17,7 +18,85 @@ export class LlmService {
     if (this.environmentService.getLocalLlmApiBase()) {
       providers.push(LlmProvider.Local);
     }
+    
     return providers;
+  }
+
+  async getModels(): Promise<{ id: string; name: string; provider: string }[]> {
+    const models: { id: string; name: string; provider: string }[] = [];
+    
+    if (this.environmentService.getOpenaiApiKey()) {
+      models.push(
+        { id: 'gpt-3.5-turbo', name: 'GPT-3.5 Turbo', provider: LlmProvider.OpenAI },
+        { id: 'gpt-4', name: 'GPT-4', provider: LlmProvider.OpenAI },
+        { id: 'gpt-4-turbo', name: 'GPT-4 Turbo', provider: LlmProvider.OpenAI }
+      );
+    }
+    
+    if (this.environmentService.getHuggingfaceApiKey()) {
+      models.push({ id: 'huggingface-default', name: 'Hugging Face Model', provider: LlmProvider.HuggingFace });
+    }
+    
+    if (this.environmentService.getLocalLlmApiBase()) {
+      try {
+        const localModels = await this.getLocalModels();
+        models.push(...localModels);
+      } catch (error: any) {
+        console.log('Failed to fetch local models:', error?.message || 'Unknown error');
+        // Fallback to configured model
+        const configuredModel = this.environmentService.getLocalLlmModel();
+        if (configuredModel) {
+          models.push({ id: configuredModel, name: configuredModel, provider: LlmProvider.Local });
+        }
+      }
+    }
+    
+    return models;
+  }
+
+  private async getLocalModels(): Promise<{ id: string; name: string; provider: string }[]> {
+    const base = this.environmentService.getLocalLlmApiBase();
+    try {
+      const response = await fetch(`${base}/v1/models`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      
+      const data = await response.json();
+      if (data.data && Array.isArray(data.data)) {
+        return data.data.map((model: any) => ({
+          id: model.id,
+          name: model.id || model.name || 'Unknown Model',
+          provider: LlmProvider.Local
+        }));
+      }
+    } catch (error: any) {
+      console.log('Local LLM models API not available:', error.message);
+    }
+    
+    // Fallback to configured model
+    const configuredModel = this.environmentService.getLocalLlmModel();
+    return configuredModel ? [{ id: configuredModel, name: configuredModel, provider: LlmProvider.Local }] : [];
+  }
+
+  async chatWithModel(modelId: string, messages: any[]): Promise<string> {
+    // Determine provider based on model ID
+    let provider: LlmProvider;
+    
+    if (['gpt-3.5-turbo', 'gpt-4', 'gpt-4-turbo'].includes(modelId)) {
+      provider = LlmProvider.OpenAI;
+      return this.callOpenAI(messages, modelId);
+    } else if (modelId === 'huggingface-default') {
+      provider = LlmProvider.HuggingFace;
+      return this.callHuggingFace(messages);
+    } else {
+      // Assume all other models are local
+      return this.callLocal(messages, modelId);
+    }
   }
 
   async chat(provider: LlmProvider, messages: any[]): Promise<string> {
@@ -33,49 +112,154 @@ export class LlmService {
     }
   }
 
-  private async callOpenAI(messages: any[]): Promise<string> {
+  private async callOpenAI(messages: any[], modelId?: string): Promise<string> {
     const apiKey = this.environmentService.getOpenaiApiKey();
     const base = this.environmentService.getOpenaiApiBase();
-    const res = await fetch(`${base}/chat/completions`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ model: 'gpt-3.5-turbo', messages }),
-    });
-    const data = await res.json();
-    return data.choices?.[0]?.message?.content || '';
+    
+    if (!apiKey) {
+      throw new Error('OpenAI API key is not configured');
+    }
+    
+    const model = modelId || 'gpt-3.5-turbo';
+    
+    try {
+      const res = await fetch(`${base}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ 
+          model, 
+          messages,
+          max_tokens: 2000,
+          temperature: 0.7
+        }),
+      });
+
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}));
+        throw new Error(
+          `OpenAI API error (${res.status}): ${errorData.error?.message || res.statusText}`
+        );
+      }
+
+      const data = await res.json();
+      
+      if (!data.choices?.[0]?.message?.content) {
+        throw new Error('Invalid response format from OpenAI API');
+      }
+      
+      return data.choices[0].message.content;
+    } catch (error: any) {
+      console.error('OpenAI API call failed:', error);
+      throw new Error(`OpenAI service error: ${error.message}`);
+    }
   }
 
   private async callHuggingFace(messages: any[]): Promise<string> {
     const apiKey = this.environmentService.getHuggingfaceApiKey();
     const base = this.environmentService.getHuggingfaceApiBase();
-    const prompt = messages.map((m) => m.content).join('\n');
-    const res = await fetch(base, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ inputs: prompt }),
-    });
-    const data = await res.json();
-    if (typeof data === 'string') {
-      return data;
+    
+    if (!apiKey || !base) {
+      throw new Error('Hugging Face API key or base URL is not configured');
     }
-    return data.generated_text || '';
+    
+    const prompt = messages.map((m) => `${m.role}: ${m.content}`).join('\n');
+    
+    try {
+      const res = await fetch(base, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ 
+          inputs: prompt,
+          parameters: {
+            max_new_tokens: 2000,
+            temperature: 0.7,
+            do_sample: true,
+            top_p: 0.9
+          }
+        }),
+      });
+
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}));
+        throw new Error(
+          `Hugging Face API error (${res.status}): ${errorData.error || res.statusText}`
+        );
+      }
+
+      const data = await res.json();
+      
+      if (typeof data === 'string') {
+        return data;
+      }
+      
+      if (Array.isArray(data) && data[0]?.generated_text) {
+        return data[0].generated_text;
+      }
+      
+      if (data.generated_text) {
+        return data.generated_text;
+      }
+      
+      throw new Error('Invalid response format from Hugging Face API');
+    } catch (error: any) {
+      console.error('Hugging Face API call failed:', error);
+      throw new Error(`Hugging Face service error: ${error.message}`);
+    }
   }
 
-  private async callLocal(messages: any[]): Promise<string> {
+  private async callLocal(messages: any[], modelId?: string): Promise<string> {
     const base = this.environmentService.getLocalLlmApiBase();
-    const model = this.environmentService.getLocalLlmModel() || 'default';
-    const res = await fetch(`${base}/v1/chat/completions`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model, messages }),
-    });
-    const data = await res.json();
-    return data.choices?.[0]?.message?.content || '';
+    
+    if (!base) {
+      throw new Error('Local LLM API base URL is not configured');
+    }
+    
+    const model = modelId || this.environmentService.getLocalLlmModel() || 'default';
+    
+    try {
+      const res = await fetch(`${base}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        },
+        body: JSON.stringify({ 
+          model, 
+          messages,
+          max_tokens: 2000,
+          temperature: 0.7,
+          stream: false
+        }),
+      });
+
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}));
+        throw new Error(
+          `Local LLM API error (${res.status}): ${errorData.error?.message || res.statusText}`
+        );
+      }
+
+      const data = await res.json();
+      
+      if (!data.choices?.[0]?.message?.content) {
+        throw new Error('Invalid response format from Local LLM API');
+      }
+      
+      return data.choices[0].message.content;
+    } catch (error: any) {
+      console.error('Local LLM API call failed:', error);
+      
+      if (error.message.includes('fetch')) {
+        throw new Error(`Cannot connect to Local LLM service at ${base}. Please check if the service is running.`);
+      }
+      
+      throw new Error(`Local LLM service error: ${error.message}`);
+    }
   }
 }

--- a/apps/server/src/integrations/llm/llm.service.ts
+++ b/apps/server/src/integrations/llm/llm.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+import { EnvironmentService } from '../environment/environment.service';
+import { LlmProvider } from './llm.types';
+
+@Injectable()
+export class LlmService {
+  constructor(private readonly environmentService: EnvironmentService) {}
+
+  getProviders(): string[] {
+    const providers: string[] = [];
+    if (this.environmentService.getOpenaiApiKey()) {
+      providers.push(LlmProvider.OpenAI);
+    }
+    if (this.environmentService.getHuggingfaceApiKey()) {
+      providers.push(LlmProvider.HuggingFace);
+    }
+    if (this.environmentService.getLocalLlmApiBase()) {
+      providers.push(LlmProvider.Local);
+    }
+    return providers;
+  }
+
+  async chat(provider: LlmProvider, messages: any[]): Promise<string> {
+    switch (provider) {
+      case LlmProvider.OpenAI:
+        return this.callOpenAI(messages);
+      case LlmProvider.HuggingFace:
+        return this.callHuggingFace(messages);
+      case LlmProvider.Local:
+        return this.callLocal(messages);
+      default:
+        throw new Error('Unknown provider');
+    }
+  }
+
+  private async callOpenAI(messages: any[]): Promise<string> {
+    const apiKey = this.environmentService.getOpenaiApiKey();
+    const base = this.environmentService.getOpenaiApiBase();
+    const res = await fetch(`${base}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ model: 'gpt-3.5-turbo', messages }),
+    });
+    const data = await res.json();
+    return data.choices?.[0]?.message?.content || '';
+  }
+
+  private async callHuggingFace(messages: any[]): Promise<string> {
+    const apiKey = this.environmentService.getHuggingfaceApiKey();
+    const base = this.environmentService.getHuggingfaceApiBase();
+    const prompt = messages.map((m) => m.content).join('\n');
+    const res = await fetch(base, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ inputs: prompt }),
+    });
+    const data = await res.json();
+    if (typeof data === 'string') {
+      return data;
+    }
+    return data.generated_text || '';
+  }
+
+  private async callLocal(messages: any[]): Promise<string> {
+    const base = this.environmentService.getLocalLlmApiBase();
+    const model = this.environmentService.getLocalLlmModel() || 'default';
+    const res = await fetch(`${base}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model, messages }),
+    });
+    const data = await res.json();
+    return data.choices?.[0]?.message?.content || '';
+  }
+}

--- a/apps/server/src/integrations/llm/llm.types.ts
+++ b/apps/server/src/integrations/llm/llm.types.ts
@@ -1,0 +1,5 @@
+export enum LlmProvider {
+  OpenAI = 'openai',
+  HuggingFace = 'huggingface',
+  Local = 'local',
+}


### PR DESCRIPTION
## Summary
- support a local LLM endpoint for Ollama or LM Studio
- expose helper getters for local LLM config
- allow the server to return `local` as a provider
- add an AI assistant modal to pages so generated text can be inserted
- document new environment variables

## Testing
- `pnpm --filter ./apps/server lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm --filter ./apps/client lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684678d96a948326a1b32282ff4bce97